### PR TITLE
feat(oauth): replace rotation limit with absolute lifetime for refresh tokens

### DIFF
--- a/src/bkauth/pkg/api/oauth/handler/token.go
+++ b/src/bkauth/pkg/api/oauth/handler/token.go
@@ -287,8 +287,6 @@ func handleTokenError(c *gin.Context, err error) {
 		c.JSON(http.StatusBadRequest, oauth.NewInvalidGrantError("Refresh token has expired"))
 	case errors.Is(err, oauth.ErrRefreshTokenRevoked):
 		c.JSON(http.StatusBadRequest, oauth.NewInvalidGrantError("Refresh token has been revoked"))
-	case errors.Is(err, oauth.ErrRotationLimitExceeded):
-		c.JSON(http.StatusBadRequest, oauth.NewInvalidGrantError("Refresh token rotation limit exceeded"))
 	default:
 		c.JSON(http.StatusInternalServerError, oauth.NewServerError("An unexpected error occurred"))
 	}

--- a/src/bkauth/pkg/api/oauth/handler/token_test.go
+++ b/src/bkauth/pkg/api/oauth/handler/token_test.go
@@ -105,8 +105,6 @@ var _ = Describe("handleTokenError", func() {
 			errorCase{oauth.ErrRefreshTokenExpired, oauth.ErrorCodeInvalidGrant, http.StatusBadRequest}),
 		Entry("refresh token revoked",
 			errorCase{oauth.ErrRefreshTokenRevoked, oauth.ErrorCodeInvalidGrant, http.StatusBadRequest}),
-		Entry("rotation limit exceeded",
-			errorCase{oauth.ErrRotationLimitExceeded, oauth.ErrorCodeInvalidGrant, http.StatusBadRequest}),
 		Entry("unexpected error",
 			errorCase{errors.New("something went wrong"), oauth.ErrorCodeServerError, http.StatusInternalServerError}),
 	)

--- a/src/bkauth/pkg/database/dao/oauth_refresh_token.go
+++ b/src/bkauth/pkg/database/dao/oauth_refresh_token.go
@@ -51,8 +51,8 @@ type OAuthRefreshToken struct {
 	// GrantID) has been rotated via refresh token rotation (RFC 6749 §6).
 	// Each successful rotation creates a new refresh token row with
 	// count = previous_token.RotationCount + 1; initial issuance starts at 0.
-	// Used to enforce oauth.MaxRefreshTokenRotations — once exceeded the
-	// grant family is revoked and the user must re-authenticate.
+	// Retained for auditing and observability; session lifetime is bounded
+	// by the absolute ExpiresAt inherited from initial issuance.
 	RotationCount int64     `db:"rotation_count"`
 	CreatedAt     time.Time `db:"created_at"`
 	UpdatedAt     time.Time `db:"updated_at"`

--- a/src/bkauth/pkg/oauth/errors.go
+++ b/src/bkauth/pkg/oauth/errors.go
@@ -159,10 +159,9 @@ var (
 
 // Refresh token errors
 var (
-	ErrInvalidRefreshToken   = errors.New("invalid refresh token")
-	ErrRefreshTokenExpired   = errors.New("refresh token expired")
-	ErrRefreshTokenRevoked   = errors.New("refresh token revoked")
-	ErrRotationLimitExceeded = errors.New("refresh token rotation limit exceeded")
+	ErrInvalidRefreshToken = errors.New("invalid refresh token")
+	ErrRefreshTokenExpired = errors.New("refresh token expired")
+	ErrRefreshTokenRevoked = errors.New("refresh token revoked")
 )
 
 // Device code errors (RFC 8628)

--- a/src/bkauth/pkg/oauth/token.go
+++ b/src/bkauth/pkg/oauth/token.go
@@ -39,14 +39,6 @@ const (
 	// (authorization_code grant, device_code grant, etc.).
 	InitialRotationCount int64 = 0
 
-	// MaxRefreshTokenRotations is the maximum number of times a grant family
-	// may rotate its refresh token before the family is revoked and the user
-	// must re-authenticate. This bounds the total session lifetime regardless
-	// of individual token TTL. For example, with a 30-minute access token TTL,
-	// 50 rotations cap the effective session at roughly 25 hours.
-	// Set to 0 to disable the limit.
-	MaxRefreshTokenRotations int64 = 50
-
 	// ReplayDetectionGracePeriod is the window after a refresh token is revoked
 	// during which a duplicate use is treated as a benign concurrent request
 	// rather than a replay attack.
@@ -68,7 +60,8 @@ const (
 	// Trade-off: a real attacker who replays within the grace window will not
 	// trigger family revocation. This is acceptable because (a) the attacker
 	// still cannot obtain new tokens, (b) the window is short, and (c) the
-	// rotation limit (MaxRefreshTokenRotations) provides an additional bound.
+	// absolute lifetime (ExpiresAt inherited from initial issuance) provides
+	// an additional bound on the grant family's total lifespan.
 	ReplayDetectionGracePeriod = 30 * time.Second
 )
 

--- a/src/bkauth/pkg/service/oauth_token.go
+++ b/src/bkauth/pkg/service/oauth_token.go
@@ -91,11 +91,15 @@ type preparedTokenPair struct {
 // prepareTokenPair generates all random material and builds DAO structs for
 // a token pair. This is pure computation with no database access, so it can
 // safely run outside a transaction to minimize lock hold time.
-// rotationCount should be oauth.InitialRotationCount for initial issuance
-// and old.RotationCount+1 for rotation.
+//
+// refreshTokenExpiresAt is the absolute expiration for the refresh token.
+// For initial issuance, pass time.Now() + RefreshTokenTTL.
+// For rotation, pass the previous token's ExpiresAt to preserve the
+// absolute lifetime (the grant family expires at the originally issued time).
 func (s *oauthTokenService) prepareTokenPair(
 	realmName, grantID, clientID, tenantID, sub, username string,
 	audience []string, rotationCount int64,
+	refreshTokenExpiresAt time.Time,
 	policy types.TokenIssuancePolicy,
 ) (preparedTokenPair, error) {
 	now := time.Now()
@@ -145,7 +149,7 @@ func (s *oauthTokenService) prepareTokenPair(
 			Sub:           sub,
 			Username:      username,
 			Audience:      string(audienceJSON),
-			ExpiresAt:     now.Add(time.Duration(policy.RefreshTokenTTL) * time.Second),
+			ExpiresAt:     refreshTokenExpiresAt,
 			Revoked:       false,
 			RotationCount: rotationCount,
 		},
@@ -202,8 +206,10 @@ func (s *oauthTokenService) generateTokenPair(
 ) (types.TokenPair, error) {
 	errorWrapf := errorx.NewLayerFunctionErrorWrapf(OAuthTokenSVC, "generateTokenPair")
 
+	refreshTokenExpiresAt := time.Now().Add(time.Duration(policy.RefreshTokenTTL) * time.Second)
 	prepared, err := s.prepareTokenPair(
-		realmName, grantID, clientID, tenantID, sub, username, audience, oauth.InitialRotationCount, policy,
+		realmName, grantID, clientID, tenantID, sub, username, audience,
+		oauth.InitialRotationCount, refreshTokenExpiresAt, policy,
 	)
 	if err != nil {
 		return types.TokenPair{}, errorWrapf(err, "prepareTokenPair fail")
@@ -376,20 +382,6 @@ func (s *oauthTokenService) RefreshAccessToken(
 		return types.TokenPair{}, oauth.ErrRefreshTokenExpired
 	}
 
-	// NOTE: MaxRefreshTokenRotations is currently a constant, so the "> 0"
-	// guard is always true. Keep it here because we plan to make this value
-	// configurable per-environment; once it becomes a runtime config, the
-	// zero-value will mean "unlimited rotations" and this guard will matter.
-	if oauth.MaxRefreshTokenRotations > 0 && daoRefreshToken.RotationCount >= oauth.MaxRefreshTokenRotations {
-		// Proactively revoke the entire grant family so that the current
-		// (still technically valid) refresh token and its associated access
-		// token cannot be used again. Without this, the token pair would
-		// remain valid until natural expiry, leaving an open window despite
-		// the rotation limit being reached.
-		_ = s.RevokeByGrantID(ctx, daoRefreshToken.GrantID)
-		return types.TokenPair{}, oauth.ErrRotationLimitExceeded
-	}
-
 	var audience []string
 	if err := json.Unmarshal([]byte(daoRefreshToken.Audience), &audience); err != nil {
 		return types.TokenPair{}, errorWrapf(err, "json.Unmarshal audience fail")
@@ -397,10 +389,13 @@ func (s *oauthTokenService) RefreshAccessToken(
 
 	// Pre-generate all random material outside the transaction to minimize
 	// the time the transaction holds locks.
+	// Carry forward the original ExpiresAt so the grant family has a fixed
+	// absolute lifetime from initial issuance — rotation does not extend it.
 	prepared, err := s.prepareTokenPair(
 		realmName, daoRefreshToken.GrantID, clientID, daoRefreshToken.TenantID,
 		daoRefreshToken.Sub, daoRefreshToken.Username,
 		audience, daoRefreshToken.RotationCount+1,
+		daoRefreshToken.ExpiresAt,
 		policy,
 	)
 	if err != nil {

--- a/src/bkauth/pkg/service/oauth_token_test.go
+++ b/src/bkauth/pkg/service/oauth_token_test.go
@@ -75,6 +75,7 @@ var _ = Describe("oauthTokenService", func() {
 			svc := oauthTokenService{}
 
 			start := time.Now()
+			refreshExpiresAt := start.Add(24 * time.Hour)
 			prepared, err := svc.prepareTokenPair(
 				"blueking",
 				"grant-1",
@@ -84,6 +85,7 @@ var _ = Describe("oauthTokenService", func() {
 				"user-1",
 				[]string{"aud-1", "aud-2"},
 				3,
+				refreshExpiresAt,
 				policy,
 			)
 
@@ -115,7 +117,7 @@ var _ = Describe("oauthTokenService", func() {
 			Expect(prepared.daoRefreshToken.TokenMask).To(Equal(oauth.MaskToken(prepared.refreshToken)))
 			Expect(prepared.daoRefreshToken.Revoked).To(BeFalse())
 			Expect(prepared.daoRefreshToken.RotationCount).To(Equal(int64(3)))
-			Expect(prepared.daoRefreshToken.ExpiresAt).To(BeTemporally("~", start.Add(time.Hour), 2*time.Second))
+			Expect(prepared.daoRefreshToken.ExpiresAt).To(Equal(refreshExpiresAt))
 
 			Expect(prepared.daoAccessToken.Audience).To(Equal(`["aud-1","aud-2"]`))
 			Expect(prepared.daoRefreshToken.Audience).To(Equal(`["aud-1","aud-2"]`))
@@ -289,30 +291,6 @@ var _ = Describe("oauthTokenService", func() {
 			Expect(err).To(MatchError(oauth.ErrRefreshTokenExpired))
 		})
 
-		It("should revoke the family when rotation limit is exceeded", func() {
-			rt := newValidRefreshTokenDAO()
-			rt.RotationCount = oauth.MaxRefreshTokenRotations
-			mockRefreshManager.EXPECT().GetByTokenHash(gomock.Any(), gomock.Any()).Return(rt, nil)
-
-			mockRefreshManager.EXPECT().
-				RevokeByGrantIDWithTx(gomock.Any(), gomock.Any(), "grant-1").
-				Return(int64(1), nil)
-			mockAccessManager.EXPECT().
-				RevokeByGrantIDWithTx(gomock.Any(), gomock.Any(), "grant-1").
-				Return(int64(1), nil)
-
-			db, dbMock := database.NewMockSqlxDB()
-			dbMock.ExpectBegin()
-			dbMock.ExpectCommit()
-			restore := useMockDefaultDB(db)
-			defer restore()
-
-			_, err := svc.RefreshAccessToken(context.Background(), "blueking", "refresh-1", "client-1", policy)
-
-			Expect(err).To(MatchError(oauth.ErrRotationLimitExceeded))
-			Expect(dbMock.ExpectationsWereMet()).To(Succeed())
-		})
-
 		It("should return wrapped error when stored audience is invalid", func() {
 			rt := newValidRefreshTokenDAO()
 			rt.Audience = "{invalid-json}"
@@ -343,9 +321,10 @@ var _ = Describe("oauthTokenService", func() {
 			Expect(dbMock.ExpectationsWereMet()).To(Succeed())
 		})
 
-		It("should revoke old tokens and persist a rotated pair", func() {
+		It("should revoke old tokens and persist a rotated pair with inherited ExpiresAt", func() {
 			rt := newValidRefreshTokenDAO()
 			rt.RotationCount = 7
+			originalExpiresAt := rt.ExpiresAt
 			mockRefreshManager.EXPECT().GetByTokenHash(gomock.Any(), gomock.Any()).Return(rt, nil)
 
 			mockRefreshManager.EXPECT().
@@ -369,6 +348,7 @@ var _ = Describe("oauthTokenService", func() {
 					Expect(token.GrantID).To(Equal("grant-1"))
 					Expect(token.RealmName).To(Equal("blueking"))
 					Expect(token.RotationCount).To(Equal(int64(8)))
+					Expect(token.ExpiresAt).To(Equal(originalExpiresAt))
 					return int64(2002), nil
 				})
 


### PR DESCRIPTION
replace rotation limit with absolute lifetime for refresh tokens

remove MaxRefreshTokenRotations (hardcoded to 50) which caused sessions to expire well before the configured RefreshTokenTTL (30 days). Instead, preserve the original ExpiresAt on rotation so it acts as an absolute lifetime — the grant family expires at the time set during initial issuance, regardless of how many rotations occur.

This aligns can be upgraded to a full dual-lifetime model (absolute + idle) later by adding a grant_expires_at column.

