### PR TITLE
fix(login): map multi-tenant login identity fields correctly

### DIFF
--- a/src/bkauth/pkg/api/web/handler/consent.go
+++ b/src/bkauth/pkg/api/web/handler/consent.go
@@ -109,6 +109,7 @@ func NewConsentInfoHandler() gin.HandlerFunc {
 // negligible — the codes are short-lived and bound to the same user/client.
 func NewConsentConfirmHandler(cfg *config.Config) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		sub := util.GetSub(c)
 		username := util.GetUsername(c)
 
 		var req consentConfirmRequest
@@ -180,7 +181,7 @@ func NewConsentConfirmHandler(cfg *config.Config) gin.HandlerFunc {
 			ClientID:            consent.ClientID,
 			TenantID:            userTenantID,
 			RealmName:           consent.RealmName,
-			Sub:                 username,
+			Sub:                 sub,
 			Username:            username,
 			RedirectURI:         consent.RedirectURI,
 			Audience:            audience,

--- a/src/bkauth/pkg/api/web/handler/device.go
+++ b/src/bkauth/pkg/api/web/handler/device.go
@@ -126,6 +126,7 @@ func NewDeviceVerifyHandler(cfg *config.Config) gin.HandlerFunc {
 // NewDeviceConfirmHandler creates a handler for POST /oauth/device/confirm
 func NewDeviceConfirmHandler(cfg *config.Config) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		sub := util.GetSub(c)
 		username := util.GetUsername(c)
 
 		var req deviceConfirmRequest
@@ -176,7 +177,7 @@ func NewDeviceConfirmHandler(cfg *config.Config) gin.HandlerFunc {
 			audience = []string{}
 		}
 
-		if err := deviceCodeSvc.ApproveByUserCode(ctx, userTenantID, req.UserCode, username, username, audience); err != nil {
+		if err := deviceCodeSvc.ApproveByUserCode(ctx, userTenantID, req.UserCode, sub, username, audience); err != nil {
 			if errors.Is(err, oauth.ErrUserCodeExpired) ||
 				errors.Is(err, oauth.ErrUserCodeAlreadyUsed) ||
 				errors.Is(err, oauth.ErrInvalidUserCode) {

--- a/src/bkauth/pkg/api/web/middleware.go
+++ b/src/bkauth/pkg/api/web/middleware.go
@@ -56,6 +56,7 @@ func LoginRequired() gin.HandlerFunc {
 			return
 		}
 
+		util.SetSub(c, loginResult.Sub)
 		util.SetUsername(c, loginResult.Username)
 		util.SetTenantID(c, loginResult.TenantID)
 		c.Next()

--- a/src/bkauth/pkg/external/bklogin/bk_ticket.go
+++ b/src/bkauth/pkg/external/bklogin/bk_ticket.go
@@ -132,6 +132,7 @@ func (v *BKTicketVerifier) Verify(ctx context.Context, ticket string) (VerifyRes
 
 	return VerifyResult{
 		Success:  true,
+		Sub:      loginResp.Data.Username,
 		Username: loginResp.Data.Username,
 	}, nil
 }

--- a/src/bkauth/pkg/external/bklogin/bk_token.go
+++ b/src/bkauth/pkg/external/bklogin/bk_token.go
@@ -137,6 +137,7 @@ func (v *BKTokenVerifier) Verify(ctx context.Context, token string) (VerifyResul
 
 	return VerifyResult{
 		Success:  true,
+		Sub:      loginResp.Data.Username,
 		Username: loginResp.Data.Username,
 	}, nil
 }

--- a/src/bkauth/pkg/external/bklogin/bklogin.go
+++ b/src/bkauth/pkg/external/bklogin/bklogin.go
@@ -29,6 +29,7 @@ import (
 
 // VerifyResult is the unified response from all BK Login verify APIs.
 type VerifyResult struct {
+	Sub      string
 	Username string
 	TenantID string
 	Success  bool

--- a/src/bkauth/pkg/external/bklogin/bklogin_suite_test.go
+++ b/src/bkauth/pkg/external/bklogin/bklogin_suite_test.go
@@ -16,22 +16,16 @@
  * to the current version of the project delivered to anyone in the future.
  */
 
-package login
+package bklogin
 
-import "context"
+import (
+	"testing"
 
-// AuthResult represents the result of a login verification.
-type AuthResult struct {
-	Sub      string
-	Username string
-	TenantID string
-	Success  bool
-	Message  string
-}
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
 
-// Authenticator defines the interface for user login verification.
-type Authenticator interface {
-	CookieName() string
-	CheckLogin(ctx context.Context, token string) (AuthResult, error)
-	GetLoginURL() string
+func TestBKLogin(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "BKLogin Suite")
 }

--- a/src/bkauth/pkg/external/bklogin/gateway.go
+++ b/src/bkauth/pkg/external/bklogin/gateway.go
@@ -43,6 +43,7 @@ const (
 type bkGatewayResponse struct {
 	Data *struct {
 		BKUsername string `json:"bk_username"`
+		LoginName  string `json:"login_name"`
 		TenantID   string `json:"tenant_id"`
 	} `json:"data"`
 	Error *struct {
@@ -152,18 +153,25 @@ func (v *BKTokenGatewayVerifier) Verify(ctx context.Context, token string) (Veri
 	}
 
 	if gatewayResp.Data == nil || gatewayResp.Data.BKUsername == "" {
-		logger.Warn("gateway verify: empty username in response")
-		return VerifyResult{Message: "empty username in login response"}, nil
+		logger.Warn("gateway verify: empty bk_username in response")
+		return VerifyResult{Message: "empty bk_username in login response"}, nil
+	}
+
+	if gatewayResp.Data.LoginName == "" {
+		logger.Warn("gateway verify: empty login_name in response")
+		return VerifyResult{Message: "empty login_name in login response"}, nil
 	}
 
 	logger.Info("gateway verify: login verified successfully",
-		zap.String("username", gatewayResp.Data.BKUsername),
+		zap.String("sub", gatewayResp.Data.BKUsername),
+		zap.String("username", gatewayResp.Data.LoginName),
 		zap.String("tenant_id", gatewayResp.Data.TenantID),
 	)
 
 	return VerifyResult{
 		Success:  true,
-		Username: gatewayResp.Data.BKUsername,
+		Sub:      gatewayResp.Data.BKUsername,
+		Username: gatewayResp.Data.LoginName,
 		TenantID: gatewayResp.Data.TenantID,
 	}, nil
 }

--- a/src/bkauth/pkg/external/bklogin/gateway_test.go
+++ b/src/bkauth/pkg/external/bklogin/gateway_test.go
@@ -1,0 +1,68 @@
+/*
+ * TencentBlueKing is pleased to support the open source community by making
+ * 蓝鲸智云 - Auth 服务 (BlueKing - Auth) available.
+ * Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://opensource.org/licenses/MIT
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * We undertake not to change the open source license (MIT license) applicable
+ * to the current version of the project delivered to anyone in the future.
+ */
+
+package bklogin
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("BKTokenGatewayVerifier", func() {
+	It("should map bk_username to sub and login_name to username", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Expect(r.URL.Query().Get("bk_token")).To(Equal("token-1"))
+			Expect(r.Header.Get("X-Bk-Tenant-Id")).To(Equal("system"))
+
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+				"data": {
+					"bk_username": "nteuuhzxlh0jcanw",
+					"tenant_id": "system",
+					"login_name": "admin",
+					"display_name": "admin",
+					"language": "zh-cn",
+					"time_zone": "Asia/Shanghai"
+				}
+			}`))
+		}))
+		defer server.Close()
+
+		oldHTTPClient := defaultHTTPClient
+		defaultHTTPClient = server.Client()
+		DeferCleanup(func() {
+			defaultHTTPClient = oldHTTPClient
+		})
+
+		verifier := &BKTokenGatewayVerifier{
+			baseURL:         server.URL,
+			authCredentials: `{"bk_app_code":"app","bk_app_secret":"secret"}`,
+		}
+
+		result, err := verifier.Verify(context.Background(), "token-1")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Success).To(BeTrue())
+		Expect(result.Sub).To(Equal("nteuuhzxlh0jcanw"))
+		Expect(result.Username).To(Equal("admin"))
+		Expect(result.TenantID).To(Equal("system"))
+	})
+})

--- a/src/bkauth/pkg/login/bk_ticket.go
+++ b/src/bkauth/pkg/login/bk_ticket.go
@@ -47,6 +47,7 @@ func (a *bkTicketAuthenticator) CheckLogin(ctx context.Context, token string) (A
 		return AuthResult{Success: false, Message: result.Message}, err
 	}
 	return AuthResult{
+		Sub:      result.Sub,
 		Username: result.Username,
 		TenantID: util.TenantIDDefault,
 		Success:  result.Success,

--- a/src/bkauth/pkg/login/bk_token.go
+++ b/src/bkauth/pkg/login/bk_token.go
@@ -47,6 +47,7 @@ func (a *bkTokenAuthenticator) CheckLogin(ctx context.Context, token string) (Au
 		return AuthResult{Success: false, Message: result.Message}, err
 	}
 	return AuthResult{
+		Sub:      result.Sub,
 		Username: result.Username,
 		TenantID: util.TenantIDDefault,
 		Success:  result.Success,

--- a/src/bkauth/pkg/login/bk_token_via_gateway.go
+++ b/src/bkauth/pkg/login/bk_token_via_gateway.go
@@ -48,6 +48,7 @@ func (a *bkTokenViaGatewayAuthenticator) CheckLogin(ctx context.Context, token s
 		return AuthResult{Success: false, Message: result.Message}, err
 	}
 	return AuthResult{
+		Sub:      result.Sub,
 		Username: result.Username,
 		TenantID: result.TenantID,
 		Success:  result.Success,

--- a/src/bkauth/pkg/util/constant.go
+++ b/src/bkauth/pkg/util/constant.go
@@ -27,6 +27,7 @@ const (
 	EnableMultiTenantModeKey = "enable_multi_tenant_mode"
 
 	ErrorIDKey   = "err"
+	SubKey       = "sub"
 	UsernameKey  = "username"
 	TenantIDKey  = "tenant_id"
 	RealmNameKey = "realm_name"

--- a/src/bkauth/pkg/util/request.go
+++ b/src/bkauth/pkg/util/request.go
@@ -79,6 +79,14 @@ func GetEnableMultiTenantMode(c *gin.Context) bool {
 	return c.GetBool(EnableMultiTenantModeKey)
 }
 
+func SetSub(c *gin.Context, sub string) {
+	c.Set(SubKey, sub)
+}
+
+func GetSub(c *gin.Context) string {
+	return c.GetString(SubKey)
+}
+
 func SetUsername(c *gin.Context, username string) {
 	c.Set(UsernameKey, username)
 }


### PR DESCRIPTION
Map BK Login gateway bk_username to OAuth sub and login_name to username. Propagate sub through login context into authorization code and device code flows. Add gateway verifier coverage for the multi-tenant identity field mapping


